### PR TITLE
Adding basic state, useEffect, and mount handler factory functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import reactLogo from "./assets/react.svg";
 import Editor from "@monaco-editor/react";
 import * as Y from "yjs";
@@ -11,16 +11,20 @@ const provider = new WebsocketProvider(
   "test-1",
   doc
 );
-const yNotebook = doc.getMap("notebook");
-const cellIdArr = ["monacoA", "monacoB"];
 
-cellIdArr.forEach((cellId) => {
-  yNotebook.set(cellId, new Y.Text());
-});
-yNotebook.set("monacoA", new Y.Text());
-yNotebook.set("monacoB", new Y.Text());
+const yNotebook = doc.getMap("notebook");
+const cellIdArr = ["monacoA", "monacoB"]; // mock data
 
 function App() {
+  const [cellIdList, setCellIdList] = useState([]);
+
+  useEffect(() => {
+    setCellIdList(() => cellIdArr);
+    cellIdList.forEach((cellId) => {
+      yNotebook.set(cellId, new Y.Text());
+    });
+  }, []);
+
   const editorRef = useRef(null);
 
   function createEditorDidMountHandler(cellId) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,14 +29,14 @@ function App() {
 
   function createEditorDidMountHandler(cellId) {
     return (editor, monaco) => {
-      editor = editor;
+      editorRef.current = editor;
 
       const type = doc.get("notebook").get(cellId);
 
       const binding = new MonacoBinding(
         type,
-        editor.getModel(),
-        new Set([editor]),
+        editorRef.current.getModel(),
+        new Set([editorRef.current]),
         provider.awareness
       );
       console.log(provider.awareness);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ function App() {
 
   return (
     <div>
-      {cellIdArr.map((cellId) => {
+      {cellIdList.map((cellId) => {
         return (
           <Editor
             key={cellId}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,44 +1,47 @@
-import { useState, useRef } from 'react'
-import reactLogo from './assets/react.svg'
-import Editor from "@monaco-editor/react"
-import * as Y from "yjs"
-import { MonacoBinding } from "y-monaco"
-import { WebsocketProvider } from 'y-websocket'
+import { useState, useRef } from "react";
+import reactLogo from "./assets/react.svg";
+import Editor from "@monaco-editor/react";
+import * as Y from "yjs";
+import { MonacoBinding } from "y-monaco";
+import { WebsocketProvider } from "y-websocket";
 
 const doc = new Y.Doc();
-const provider = new WebsocketProvider('ws://localhost:1234', 'test', doc);
-const yNotebook = doc.getMap('notebook');
-const cellIdArr = ['monacoA', 'monacoB']
+const provider = new WebsocketProvider(
+  import.meta.env.VITE_WEBSOCKET_SERVER,
+  "test-1",
+  doc
+);
+const yNotebook = doc.getMap("notebook");
+const cellIdArr = ["monacoA", "monacoB"];
 
 cellIdArr.forEach((cellId) => {
   yNotebook.set(cellId, new Y.Text());
-})
-// yNotebook.set('monacoA', new Y.Text());
-// yNotebook.set('monacoB', new Y.Text());
+});
+yNotebook.set("monacoA", new Y.Text());
+yNotebook.set("monacoB", new Y.Text());
 
 function App() {
   const editorRef = useRef(null);
 
-  function handleEditorDidMountA(editor, monaco) {
-    editor = editor;
- 
-    const type = doc.get('notebook').get("monacoA"); 
+  function createEditorDidMountHandler(cellId) {
+    return (editor, monaco) => {
+      editor = editor;
 
-    const binding = new MonacoBinding(type, editor.getModel(),new Set([editor]), provider.awareness)
-    console.log(provider.awareness);                
+      const type = doc.get("notebook").get(cellId);
+
+      const binding = new MonacoBinding(
+        type,
+        editor.getModel(),
+        new Set([editor]),
+        provider.awareness
+      );
+      console.log(provider.awareness);
+    };
   }
-  function handleEditorDidMountB(editor, monaco) {
-    editor = editor;
 
-    const type = doc.get('notebook').get("monacoB");
-
-    const binding = new MonacoBinding(type, editor.getModel(), new Set([editor]), provider.awareness)
-    console.log(provider.awareness);                
-  }
-  
   return (
-    <div> 
-      {/* {cellIdArr.map((cellId) => {
+    <div>
+      {cellIdArr.map((cellId) => {
         return (
           <Editor
             key={cellId}
@@ -46,27 +49,12 @@ function App() {
             height="35vh"
             width="100vw"
             theme="vs-dark"
-            onMount={handleEditorDidMount}
+            onMount={createEditorDidMountHandler(cellId)}
           />
-        )
-      }  )}  */}
-       <Editor
-      defaultValue='Editor A default value from editor component'
-      height="35vh"
-      width="100vw"
-      theme="vs-dark"
-      onMount={handleEditorDidMountA}
-    />
-      <Editor
-      defaultValue='Editor B default value from editor component'
-      height="35vh"
-      width="100vw"
-      theme="vs-dark"
-      onMount={handleEditorDidMountB}
-    />
+        );
+      })}
     </div>
-
-  )
+  );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
A few updates

**State management**
* `useEffect` sets state **`cellIdList`** to mock data `cellIdArr`. Then it sets `cellId` - `yText` kv pairs on `yNotebook`. 

**Refactoring editor instance rendering & factory function**
* Transformation of `cellIdArr` into `Editor` components. `onMount` takes the handler created by the new factory function **`createEditorDidMountHandler`**
    * (it takes a `cellId` and creates an `onMount` handler that creates a binding for that cell's `yText` )

**misc**
* WS Provider now takes the URI specified by an `.env` file (`import.meta.env.VITE_WEBSOCKET_SERVER`). It's your heroku-hosted WSS.
* made use of `editorRef` hook to cache editor