### PR TITLE
Mock data transformers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,23 +6,46 @@ import { MonacoBinding } from "y-monaco";
 import { WebsocketProvider } from "y-websocket";
 import { useReactive } from "@reactivedata/react";
 
-// Choose 1 of the following 2 lines to use mock data
 
-// import { useMockCellIDListEffects, doc } from "./mocking/useMockCellIDListEffects";
+import { mockJsonToYDoc, mockCellsToYDoc } from "./mocking/mockDataToYDoc";
 
-// import { useMockNotebookEffects, doc } from "./mocking/useMockNotebookEffects";
-
-import { mockCellsToYDoc } from "./mocking/mockCellArrToYDoc";
-
-// end note
 
 console.log("test nodemon change");
 
+// to test mockCellsToYDoc
 const doc = mockCellsToYDoc(
   { id: "cellIdA", content: "console.log('hello i am cell A');", type: "code" },
   { id: "cellIdB", content: "console.log('hello i am cell B');", type: "code" },
   { id: "cellIdC", content: "console.log('meow (cell 3)');", type: "code" }
 );
+
+// to testMockJsonToYDoc
+// const doc = mockJsonToYDoc(JSON.stringify({
+//   "notebook": {
+//     "rawCellData": {
+//       "cellIdA": {
+//         "id": "cellIdA",
+//         "content": "console.log('hello i am cell A dude');",
+//         "type": "code"
+//       },
+//       "cellIdB": {
+//         "id": "cellIdB",
+//         "content": "console.log('hello i am cell B dude');",
+//         "type": "code"
+//       },
+//       "cellIdC": {
+//         "id": "cellIdC",
+//         "content": "console.log('meow (cell 3 dude)');",
+//         "type": "code"
+//       }
+//     },
+//     "cellOrderArr": [
+//       "cellIdA",
+//       "cellIdB",
+//       "cellIdC"
+//     ]
+//   }
+// }));
 
 const provider = new WebsocketProvider(
   import.meta.env.VITE_WEBSOCKET_SERVER,
@@ -31,10 +54,6 @@ const provider = new WebsocketProvider(
 );
 
 function App() {
-  // pick one of the following 2 lines to use mock data
-  // const [cellIdList, setCellIdList] = useMockNotebookEffects();
-  // const [cellIdList, setCellIdList] = useMockCellIDListEffects();
-
   const [cellIdList, setCellIdList] = useState([]);
   const [document, setDocument] = useState(null);
 
@@ -53,13 +72,11 @@ function App() {
     return (editor, monaco) => {
       editorRef.current = editor;
 
-      // pick one of the following 2 lines to use mock data
       const type = document
         .get("notebook")
         .get("rawCellData")
         .get(cellId)
         .get("content");
-      // const type = doc.get("notebook").get(cellId);
 
       const binding = new MonacoBinding(
         type,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,11 +10,19 @@ import { useReactive } from "@reactivedata/react";
 
 // import { useMockCellIDListEffects, doc } from "./mocking/useMockCellIDListEffects";
 
-import { useMockNotebookEffects, doc } from "./mocking/useMockNotebookEffects";
+// import { useMockNotebookEffects, doc } from "./mocking/useMockNotebookEffects";
+
+import { mockCellsToYDoc } from "./mocking/mockCellArrToYDoc";
 
 // end note
 
-console.log('test nodemon change')
+console.log("test nodemon change");
+
+const doc = mockCellsToYDoc(
+  { id: "cellIdA", content: "console.log('hello i am cell A');", type: "code" },
+  { id: "cellIdB", content: "console.log('hello i am cell B');", type: "code" },
+  { id: "cellIdC", content: "console.log('meow (cell 3)');", type: "code" }
+);
 
 const provider = new WebsocketProvider(
   import.meta.env.VITE_WEBSOCKET_SERVER,
@@ -22,11 +30,23 @@ const provider = new WebsocketProvider(
   doc
 );
 
-
 function App() {
   // pick one of the following 2 lines to use mock data
-  const [cellIdList, setCellIdList] = useMockNotebookEffects();
+  // const [cellIdList, setCellIdList] = useMockNotebookEffects();
   // const [cellIdList, setCellIdList] = useMockCellIDListEffects();
+
+  const [cellIdList, setCellIdList] = useState([]);
+  const [document, setDocument] = useState(null);
+
+  const loadDoc = () => {
+    setDocument(doc);
+    setCellIdList(() => doc.get("notebook").get("cellOrderArr").toArray());
+  };
+
+  useEffect(() => {
+    loadDoc();
+  }, []);
+
   const editorRef = useRef(null);
 
   function createEditorDidMountHandler(cellId) {
@@ -34,7 +54,11 @@ function App() {
       editorRef.current = editor;
 
       // pick one of the following 2 lines to use mock data
-      const type = doc.get("notebook").get("rawCellData").get(cellId).get("content");
+      const type = document
+        .get("notebook")
+        .get("rawCellData")
+        .get(cellId)
+        .get("content");
       // const type = doc.get("notebook").get(cellId);
 
       const binding = new MonacoBinding(

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,18 +6,16 @@ import { MonacoBinding } from "y-monaco";
 import { WebsocketProvider } from "y-websocket";
 import { useReactive } from "@reactivedata/react";
 
-
 import { mockJsonToYDoc, mockCellsToYDoc } from "./mocking/mockDataToYDoc";
-
 
 console.log("test nodemon change");
 
 // to test mockCellsToYDoc
-const doc = mockCellsToYDoc(
+const doc = mockCellsToYDoc([
   { id: "cellIdA", content: "console.log('hello i am cell A');", type: "code" },
   { id: "cellIdB", content: "console.log('hello i am cell B');", type: "code" },
-  { id: "cellIdC", content: "console.log('meow (cell 3)');", type: "code" }
-);
+  { id: "cellIdC", content: "console.log('meow (cell 3)');", type: "code" },
+]);
 
 // to testMockJsonToYDoc
 // const doc = mockJsonToYDoc(JSON.stringify({

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,38 +6,36 @@ import { MonacoBinding } from "y-monaco";
 import { WebsocketProvider } from "y-websocket";
 import { useReactive } from "@reactivedata/react";
 
+// Choose 1 of the following 2 lines to use mock data
+
+// import { useMockCellIDListEffects, doc } from "./mocking/useMockCellIDListEffects";
+
+import { useMockNotebookEffects, doc } from "./mocking/useMockNotebookEffects";
+
+// end note
+
 console.log('test nodemon change')
 
-const doc = new Y.Doc();
 const provider = new WebsocketProvider(
   import.meta.env.VITE_WEBSOCKET_SERVER,
   import.meta.env.VITE_ROTATING_ROOM || "test-room4",
   doc
 );
 
-const yNotebook = doc.getMap("notebook");
-const cellIdArr = ["monacoA", "monacoB"]; // mock data
 
 function App() {
-  const [cellIdList, setCellIdList] = useState([]);
-  useEffect(() => {
-    setCellIdList(() => cellIdArr);
-  }, []);
-
-  useEffect(() => {
-    cellIdArr.forEach((cellId) => {
-      yNotebook.set(cellId, new Y.Text('useEffect default value'));
-    });
-    console.log(yNotebook.toJSON())
-  }, []);
-
+  // pick one of the following 2 lines to use mock data
+  const [cellIdList, setCellIdList] = useMockNotebookEffects();
+  // const [cellIdList, setCellIdList] = useMockCellIDListEffects();
   const editorRef = useRef(null);
 
   function createEditorDidMountHandler(cellId) {
     return (editor, monaco) => {
       editorRef.current = editor;
 
-      const type = doc.get("notebook").get(cellId);
+      // pick one of the following 2 lines to use mock data
+      const type = doc.get("notebook").get("rawCellData").get(cellId).get("content");
+      // const type = doc.get("notebook").get(cellId);
 
       const binding = new MonacoBinding(
         type,
@@ -51,6 +49,7 @@ function App() {
 
   return (
     <div>
+      <h3>multiMonacoSimple</h3>
       {cellIdList.map((cellId) => {
         return (
           <Editor

--- a/src/mocking/mockCellArrToYDoc.js
+++ b/src/mocking/mockCellArrToYDoc.js
@@ -6,11 +6,16 @@ const yPrettyPrint = (ydoc, msg = "") => {
   );
 };
 
+const OBSERVE_CELL_ORDER_ARR = false;
+const OBSERVE_NOTEBOOK_YMAP = false;
+const OBSERVE_CELL_DATA_YMAP = false;
+const OBSERVE_CELL_CONTENT_YTEXT = false;
+
 const mockCellsDummyData = [
   { id: "cellId1", content: "console.log('cell 1');", type: "code" },
   { id: "cellId2", content: "console.log('cell 2');", type: "code" },
   { id: "cellId3", content: "console.log('cell 3');", type: "code" }
-]
+];
 
 export const mockCellsToYDoc = (...cells) => {
   if (cells.length === 0) cells = mockCellsDummyData;
@@ -23,6 +28,11 @@ export const mockCellsToYDoc = (...cells) => {
   for (let cell of cells) {
     const cellBodyYMap = new Y.Map();
     const contentYText = new Y.Text(cell.content);
+
+    if (OBSERVE_CELL_CONTENT_YTEXT) {
+      setCellTextObserver(contentYText, cell.id);
+    }
+
     cellBodyYMap.set("id", cell.id);
     cellBodyYMap.set("content", contentYText);
     cellBodyYMap.set("type", cell.type);
@@ -33,11 +43,50 @@ export const mockCellsToYDoc = (...cells) => {
 
   const cellOrderArrYArray = new Y.Array();
   yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
-  
+
   const cellIdArr = cells.map(cell => cell.id);
   cellOrderArrYArray.insert(0, cellIdArr);
 
   yPrettyPrint(mockDoc, "last print of nbmg");
 
   return mockDoc;
+};
+
+const observers = {
+  cellContentText(contentYText, id) {
+    contentYText.observe(event => {
+      console.log(
+        `Change Detected on cell ${id}  - delta: `,
+        event.changes.delta
+      );
+    });
+  },
+
+  cellDataArr(cellDataYMap) {
+    cellDataYMap.observe(event => {
+      console.log(
+        "\n\nEvent detected on cellDataYMap - delta: ",
+        event.changes.delta
+      );
+    });
+  },
+
+  cellOrderArr(cellOrderArrYArray) {
+    cellOrderArrYArray.observe(yarrayEvent => {
+      console.log(
+        "\n\nEvent detected on cellOrderArr - delta: ",
+        yarrayEvent.changes.delta
+      );
+    });
+  },
+
+  notebook(notebookYMap) {
+    yNotebookYMap.observeDeep(event => {
+      console.log("\n\nEvent fired on notebook ymap: ");
+      console.log("==> event path: ", event.path);
+      console.log("==> event target: ", event.target);
+      console.log("==> event type: ", event.currentTarget);
+      // console.log("notebook ymap event", event);
+    });
+  }
 };

--- a/src/mocking/mockCellArrToYDoc.js
+++ b/src/mocking/mockCellArrToYDoc.js
@@ -24,6 +24,9 @@ export const mockCellsToYDoc = (...cells) => {
   const yNotebookYMap = mockDoc.getMap("notebook");
   const cellDataYMap = new Y.Map();
   yNotebookYMap.set("rawCellData", cellDataYMap);
+  if (OBSERVE_CELL_DATA_YMAP) {
+    observervability.cellDataYMap(cellDataYMap);
+  }
 
   if (OBSERVE_NOTEBOOK_YMAP) {
     observervability.notebook(yNotebookYMap);
@@ -70,7 +73,7 @@ const observervability = {
     });
   },
 
-  cellDataArr(cellDataYMap) {
+  cellDataYMap(cellDataYMap) {
     cellDataYMap.observe(event => {
       console.log(
         "\n\nEvent detected on cellDataYMap - delta: ",

--- a/src/mocking/mockCellArrToYDoc.js
+++ b/src/mocking/mockCellArrToYDoc.js
@@ -25,12 +25,16 @@ export const mockCellsToYDoc = (...cells) => {
   const cellDataYMap = new Y.Map();
   yNotebookYMap.set("rawCellData", cellDataYMap);
 
+  if (OBSERVE_NOTEBOOK_YMAP) {
+    observervability.notebook(yNotebookYMap);
+  }
+
   for (let cell of cells) {
     const cellBodyYMap = new Y.Map();
     const contentYText = new Y.Text(cell.content);
 
     if (OBSERVE_CELL_CONTENT_YTEXT) {
-      setCellTextObserver(contentYText, cell.id);
+      observervability.cellContentText(contentYText, cell.id);
     }
 
     cellBodyYMap.set("id", cell.id);
@@ -44,6 +48,10 @@ export const mockCellsToYDoc = (...cells) => {
   const cellOrderArrYArray = new Y.Array();
   yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
 
+  if (OBSERVE_CELL_ORDER_ARR) {
+    observersability.cellOrderArr(cellOrderArrYArray);
+  }
+
   const cellIdArr = cells.map(cell => cell.id);
   cellOrderArrYArray.insert(0, cellIdArr);
 
@@ -52,7 +60,7 @@ export const mockCellsToYDoc = (...cells) => {
   return mockDoc;
 };
 
-const observers = {
+const observervability = {
   cellContentText(contentYText, id) {
     contentYText.observe(event => {
       console.log(

--- a/src/mocking/mockCellArrToYDoc.js
+++ b/src/mocking/mockCellArrToYDoc.js
@@ -1,0 +1,43 @@
+import * as Y from "yjs";
+
+const yPrettyPrint = (ydoc, msg = "") => {
+  console.log(
+    "\n\n==> " + msg + ": \n" + JSON.stringify(ydoc.toJSON(), null, 4) + "\n\n"
+  );
+};
+
+const mockCellsDummyData = [
+  { id: "cellId1", content: "console.log('cell 1');", type: "code" },
+  { id: "cellId2", content: "console.log('cell 2');", type: "code" },
+  { id: "cellId3", content: "console.log('cell 3');", type: "code" }
+]
+
+export const mockCellsToYDoc = (...cells) => {
+  if (cells.length === 0) cells = mockCellsDummyData;
+
+  const mockDoc = new Y.Doc();
+  const yNotebookYMap = mockDoc.getMap("notebook");
+  const cellDataYMap = new Y.Map();
+  yNotebookYMap.set("rawCellData", cellDataYMap);
+
+  for (let cell of cells) {
+    const cellBodyYMap = new Y.Map();
+    const contentYText = new Y.Text(cell.content);
+    cellBodyYMap.set("id", cell.id);
+    cellBodyYMap.set("content", contentYText);
+    cellBodyYMap.set("type", cell.type);
+    cellDataYMap.set(cell.id, cellBodyYMap);
+  }
+
+  console.log("rawCellData populated", JSON.stringify(mockDoc.toJSON()));
+
+  const cellOrderArrYArray = new Y.Array();
+  yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
+  
+  const cellIdArr = cells.map(cell => cell.id);
+  cellOrderArrYArray.insert(0, cellIdArr);
+
+  yPrettyPrint(mockDoc, "last print of nbmg");
+
+  return mockDoc;
+};

--- a/src/mocking/mockDataToYDoc.js
+++ b/src/mocking/mockDataToYDoc.js
@@ -1,0 +1,101 @@
+import * as Y from "yjs";
+
+const yPrettyPrint = (ydoc, msg = "") => {
+  console.log(
+    "\n\n==> " + msg + ": \n" + JSON.stringify(ydoc.toJSON(), null, 4) + "\n\n"
+  );
+};
+
+const mockJsonData = JSON.stringify({
+  "notebook": {
+    "rawCellData": {
+      "cellIdA": {
+        "id": "cellIdA",
+        "content": "console.log('hello i am cell A');",
+        "type": "code"
+      },
+      "cellIdB": {
+        "id": "cellIdB",
+        "content": "console.log('hello i am cell B');",
+        "type": "code"
+      },
+      "cellIdC": {
+        "id": "cellIdC",
+        "content": "console.log('meow (cell 3)');",
+        "type": "code"
+      }
+    },
+    "cellOrderArr": [
+      "cellIdA",
+      "cellIdB",
+      "cellIdC"
+    ]
+  }
+});
+
+const mockCellsDummyData = [
+  { id: "cellId1", content: "console.log('cell 1');", type: "code" },
+  { id: "cellId2", content: "console.log('cell 2');", type: "code" },
+  { id: "cellId3", content: "console.log('cell 3');", type: "code" }
+]
+
+export const mockCellsToYDoc = (...cells) => {
+  if (cells.length === 0) cells = mockCellsDummyData;
+
+  const mockDoc = new Y.Doc();
+  const yNotebookYMap = mockDoc.getMap("notebook");
+  const cellDataYMap = new Y.Map();
+  yNotebookYMap.set("rawCellData", cellDataYMap);
+
+  for (let cell of cells) {
+    const cellBodyYMap = new Y.Map();
+    const contentYText = new Y.Text(cell.content);
+    cellBodyYMap.set("id", cell.id);
+    cellBodyYMap.set("content", contentYText);
+    cellBodyYMap.set("type", cell.type);
+    cellDataYMap.set(cell.id, cellBodyYMap);
+  }
+
+  console.log("rawCellData populated", JSON.stringify(mockDoc.toJSON()));
+
+  const cellOrderArrYArray = new Y.Array();
+  yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
+  
+  const cellIdArr = cells.map(cell => cell.id);
+  cellOrderArrYArray.insert(0, cellIdArr);
+
+  yPrettyPrint(mockDoc, "last print of nbmg");
+
+  return mockDoc;
+};
+
+export const mockJsonToYDoc = (json) => {
+  if (!json) json = mockJsonData;
+  json = JSON.parse(json);
+
+  const mockDoc = new Y.Doc();
+  const yNotebookYMap = mockDoc.getMap("notebook");
+  const cellDataYMap = new Y.Map();
+  yNotebookYMap.set("rawCellData", cellDataYMap);
+
+  for (let entry of Object.entries(json.notebook.rawCellData)) {
+    const cellBodyYMap = new Y.Map();
+    const contentYText = new Y.Text(entry[1].content);
+    cellBodyYMap.set("id", entry[1].id);
+    cellBodyYMap.set("content", contentYText);
+    cellBodyYMap.set("type", entry[1].type);
+    cellDataYMap.set(entry[0], cellBodyYMap);
+  }
+
+  console.log("rawCellData populated", JSON.stringify(mockDoc.toJSON()));
+
+  const cellOrderArrYArray = new Y.Array();
+  yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
+
+
+  cellOrderArrYArray.insert(0, json.notebook.cellOrderArr);
+
+  yPrettyPrint(mockDoc, "last print of nbmg");
+
+  return mockDoc;
+};

--- a/src/mocking/mockDataToYDoc.js
+++ b/src/mocking/mockDataToYDoc.js
@@ -39,7 +39,7 @@ const mockCellsDummyData = [
   { id: "cellId3", content: "console.log('cell 3');", type: "code" }
 ]
 
-export const mockCellsToYDoc = (...cells) => {
+export const mockCellsToYDoc = (cells) => {
   if (cells.length === 0) cells = mockCellsDummyData;
 
   const mockDoc = new Y.Doc();

--- a/src/mocking/mockDataToYDoc.js
+++ b/src/mocking/mockDataToYDoc.js
@@ -40,7 +40,7 @@ const mockCellsDummyData = [
 ]
 
 export const mockCellsToYDoc = (cells) => {
-  if (cells.length === 0) cells = mockCellsDummyData;
+  if (!cells) cells = mockCellsDummyData;
 
   const mockDoc = new Y.Doc();
   const yNotebookYMap = mockDoc.getMap("notebook");

--- a/src/mocking/useMockCellIDListEffects.js
+++ b/src/mocking/useMockCellIDListEffects.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import * as Y from "yjs";
+
+export const doc = new Y.Doc();
+export const yNotebook = doc.getMap("notebook");
+const cellIdArr = ["monacoA", "monacoB"]; // mock data
+
+export function useMockCellIDListEffects() {
+  const [cellIdList, setCellIdList] = useState([]);
+  useEffect(() => {
+     setCellIdList(() => cellIdArr);
+   }, []);
+  
+   useEffect(() => {
+     cellIdArr.forEach((cellId) => {
+       yNotebook.set(cellId, new Y.Text('useEffect default value'));
+     });
+     console.log(yNotebook.toJSON())
+   }, []);
+
+   return [ cellIdList, doc ]
+}
+

--- a/src/mocking/useMockNotebookEffects.js
+++ b/src/mocking/useMockNotebookEffects.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import * as Y from "yjs";
+
+import { mockDoc } from "../notebookMockGenerator";
+
+export const doc = mockDoc;
+export const yNotebook = doc.get("notebook");
+const cellIdArr = yNotebook.get("cellOrderArr").toArray(); // mock data
+
+export function useMockNotebookEffects() {
+  const [cellIdList, setCellIdList] = useState([]);
+  useEffect(() => {
+    setCellIdList(() => cellIdArr);
+  }, []);
+
+  useEffect(() => {
+    // cellIdArr.forEach((cellId) => {
+    //   yNotebook.set(cellId, new Y.Text('useEffect default value'));
+    // });
+    console.log(yNotebook.toJSON())
+  }, []);
+
+  return [cellIdList, setCellIdList]
+}
+

--- a/src/notebookMockGenerator.js
+++ b/src/notebookMockGenerator.js
@@ -1,9 +1,9 @@
 import * as Y from "yjs";
 
-const OBSERVE_CELL_ORDER_ARR = false;
+const OBSERVE_CELL_ORDER_ARR = true;
 const OBSERVE_NOTEBOOK_YMAP = false;
-const OBSERVE_CELL_DATA_YMAP = false;
-const OBSERVE_CELL_CONTENT_YTEXT = false;
+const OBSERVE_CELL_DATA_YMAP = true;
+const OBSERVE_CELL_CONTENT_YTEXT = true;
 
 const yPrettyPrint = (ydoc, msg = "") => {
   console.log(

--- a/src/notebookMockGenerator.js
+++ b/src/notebookMockGenerator.js
@@ -1,23 +1,88 @@
 import * as Y from "yjs";
 
+const OBSERVE_CELL_ORDER_ARR = false;
+const OBSERVE_NOTEBOOK_YMAP = false;
+const OBSERVE_CELL_DATA_YMAP = false;
+const OBSERVE_CELL_CONTENT_YTEXT = false;
+
 const yPrettyPrint = (ydoc, msg = "") => {
   console.log(
     "\n\n==> " + msg + ": \n" + JSON.stringify(ydoc.toJSON(), null, 4) + "\n\n"
   );
 };
 
-const mockDoc = new Y.Doc();
+// ==> mockDoc:
+// {
+//     "notebook": {
+//         "rawCellData": {},
+//         "cellOrderArr": []
+//     }
+// }
 
-// create a hash map for our data
+const mockDoc = new Y.Doc();
 const yNotebookYMap = mockDoc.getMap("notebook");
 
+const cellDataYMap = new Y.Map();
+yNotebookYMap.set("rawCellData", cellDataYMap);
+
+const cellOrderArrYArray = new Y.Array();
+yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
+
+yPrettyPrint(mockDoc, "mockDoc");
+
+/////////////////// event handlers for updates ///////////////////////
+
+mockDoc.on("update", update => {
+  // Y.logUpdate(update); // big object with change details
+  // console.log("update", update); // array of bytes
+});
+
+/////////////////// top level notebook data ///////////////////////
+// create a hash map for our data
+
+if (OBSERVE_NOTEBOOK_YMAP) {
+  yNotebookYMap.observeDeep(event => {
+    console.log("\n\nEvent fired on notebook ymap: ");
+    console.log("==> event path: ", event.path);
+    console.log("==> event target: ", event.target);
+    console.log("==> event type: ", event.currentTarget);
+    // console.log("notebook ymap event", event);
+  });
+}
+
+if (OBSERVE_CELL_ORDER_ARR) {
+  cellOrderArrYArray.observe(yarrayEvent => {
+    console.log(
+      "\n\nEvent detected on cellOrderArr - delta: ",
+      yarrayEvent.changes.delta
+    );
+  });
+}
+
+if (OBSERVE_CELL_DATA_YMAP) {
+  cellDataYMap.observe(event => {
+    console.log(
+      "\n\nEvent detected on cellDataYMap - delta: ",
+      event.changes.delta
+    );
+  });
+}
+
+const setCellTextObserver = (contentYText, cellId) => {
+  if (OBSERVE_CELL_CONTENT_YTEXT) {
+    contentYText.observe(event => {
+      console.log(
+        `Change Detected on cell ${id}  - delta: `,
+        event.changes.delta
+      );
+    });
+  }
+};
 /////////////////// add and populate rawCellData ///////////////////////
 // unordered and accessed by cellId key
 // make load up a ymap
-const cellDataYMap = new Y.Map();
 
 // nest the ymap in mockDoc
-yNotebookYMap.set("rawCellData", cellDataYMap);
 
 const mockCellsDummyData = {
   cellId1: { id: "cellId1", content: "I am cell 1", type: "code" },
@@ -30,6 +95,11 @@ const mockCellsDummyData = {
 for (const [key, { id, content, type }] of Object.entries(mockCellsDummyData)) {
   const cellBodyYMap = new Y.Map();
   const contentYText = new Y.Text(content);
+
+  if (OBSERVE_CELL_CONTENT_YTEXT) {
+    setCellTextObserver(contentYText, id);
+  }
+
   cellBodyYMap.set("id", id);
   cellBodyYMap.set("content", contentYText);
   cellBodyYMap.set("type", type);
@@ -37,20 +107,22 @@ for (const [key, { id, content, type }] of Object.entries(mockCellsDummyData)) {
   cellDataYMap.set(key, cellBodyYMap);
 }
 
-console.log("rawCellData populated", JSON.stringify(mockDoc.toJSON()));
+cellDataYMap.get("cellId1").get("content").insert(0, "hello world");
+
+yPrettyPrint(cellDataYMap, "cellDataYmap populated");
 
 /////////////////// add and populate cellOrderArr ///////////////////////
 // kept in display order
 
 // create a yArray
-const cellOrderArrYArray = new Y.Array();
-yNotebookYMap.set("cellOrderArr", cellOrderArrYArray);
+
+// CANNOT DETECT PUSH EVENTS ON THE ARRAY
 
 for (const cellId of Object.keys(mockCellsDummyData)) {
   cellOrderArrYArray.push([cellId]);
 }
 
-console.log(mockDoc.get("notebook").get("rawCellData").get("cellId1").toJSON());
+// console.log(mockDoc.get("notebook").get("rawCellData").get("cellId1").toJSON());
 
 yPrettyPrint(mockDoc, "last print of nbmg");
 


### PR DESCRIPTION
Two functions for creating Ydocs from mock data in `mockDataToYDoc.js`

**`mockJsonToYDoc`**: Takes stringified JSON in the standard ydoc shape, and returns yDoc
```
// schema of input
"notebook": {
    "rawCellData": {
      "cellId": {
        "id",
        "content",
        "type"
      },
    },
    "cellOrderArr": [
    ]
  }
```

**`mockCellsToYDoc`**: Takes an array of objects  in the shape of a cell value `{id, content, type}`, and returns a ydoc

